### PR TITLE
V0.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,20 @@ Build jar from source with
 ```shell
 ./gradlew build
 ```
-and find the output JAR file as `build/libs/restructurehdfs-0.2.1-all.jar`. Then run with:
+and find the output JAR file as `build/libs/restructurehdfs-0.3-all.jar`. Then run with:
 
 ```shell
-java -jar restructurehdfs-0.2.1-all.jar <webhdfs_url> <hdfs_topic_path> <output_folder>
+java -jar restructurehdfs-0.3-all.jar <webhdfs_url> <hdfs_topic_path> <output_folder>
 ```
 
 By default, this will output the data in CSV format. If JSON format is preferred, use the following instead:
 ```
-java -Dorg.radarcns.format=json -jar restructurehdfs-0.2.1-all.jar <webhdfs_url> <hdfs_topic_path> <output_folder>
+java -Dorg.radarcns.format=json -jar restructurehdfs-0.3-all.jar <webhdfs_url> <hdfs_topic_path> <output_folder>
 ```
 
 Another option is to output the data in compressed form. All files will get the `gz` suffix, and can be decompressed with a GZIP decoder. Note that for a very small number of records, this may actually increase the file size.
 ```
-java -Dorg.radarcns.compress=gzip -jar restructurehdfs-0.2.1-all.jar <webhdfs_url> <hdfs_topic_path> <output_folder>
+java -Dorg.radarcns.compress=gzip -jar restructurehdfs-0.3-all.jar <webhdfs_url> <hdfs_topic_path> <output_folder>
 ```
 
 Finally, files records are deduplicated after writing. To disable this behaviour, specify the option `-Dorg.radarcns.deduplicate=false`.

--- a/README.md
+++ b/README.md
@@ -30,3 +30,5 @@ Another option is to output the data in compressed form. All files will get the 
 ```
 java -Dorg.radarcns.compress=gzip -jar restructurehdfs-0.2.1-all.jar <webhdfs_url> <hdfs_topic_path> <output_folder>
 ```
+
+Finally, files records are deduplicated after writing. To disable this behaviour, specify the option `-Dorg.radarcns.deduplicate=false`.

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 group 'org.radarcns.restructurehdfs'
-version '0.2.1'
+version '0.2.2-SNAPSHOT'
 mainClassName = 'org.radarcns.RestructureAvroRecords'
 
 run {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 group 'org.radarcns.restructurehdfs'
-version '0.2.2-SNAPSHOT'
+version '0.3'
 mainClassName = 'org.radarcns.RestructureAvroRecords'
 
 run {

--- a/src/main/java/org/radarcns/OffsetRangeSet.java
+++ b/src/main/java/org/radarcns/OffsetRangeSet.java
@@ -17,9 +17,7 @@
 package org.radarcns;
 
 import javax.annotation.Nonnull;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.SortedMap;
 import java.util.SortedSet;

--- a/src/main/java/org/radarcns/util/CsvAvroConverter.java
+++ b/src/main/java/org/radarcns/util/CsvAvroConverter.java
@@ -21,17 +21,18 @@ import com.fasterxml.jackson.dataformat.csv.CsvFactory;
 import com.fasterxml.jackson.dataformat.csv.CsvGenerator;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.GenericRecord;
+
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.avro.Schema;
-import org.apache.avro.Schema.Field;
-import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericFixed;
-import org.apache.avro.generic.GenericRecord;
 
 /**
  * Converts deep hierarchical Avro records into flat CSV format. It uses a simple dot syntax in the
@@ -42,7 +43,17 @@ public class CsvAvroConverter implements RecordConverter {
 
     public static RecordConverterFactory getFactory() {
         CsvFactory factory = new CsvFactory();
-        return (writer, record, writeHeader) -> new CsvAvroConverter(factory, writer, record, writeHeader);
+        return new RecordConverterFactory() {
+            @Override
+            public RecordConverter converterFor(Writer writer, GenericRecord record, boolean writeHeader) throws IOException {
+                return new CsvAvroConverter(factory, writer, record, writeHeader);
+            }
+
+            @Override
+            public boolean hasHeader() {
+                return true;
+            }
+        };
     }
 
     private final ObjectWriter csvWriter;

--- a/src/main/java/org/radarcns/util/FileCache.java
+++ b/src/main/java/org/radarcns/util/FileCache.java
@@ -18,40 +18,41 @@ package org.radarcns.util;
 
 import java.io.BufferedOutputStream;
 import java.io.Closeable;
-import java.io.File;
 import java.io.FileOutputStream;
 import java.io.Flushable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.zip.GZIPOutputStream;
 import javax.annotation.Nonnull;
 import org.apache.avro.generic.GenericRecord;
 
-/** Keeps file handles of a file. */
+/** Keeps path handles of a path. */
 public class FileCache implements Closeable, Flushable, Comparable<FileCache> {
     private final OutputStream[] streams;
     private final Writer writer;
     private final RecordConverter recordConverter;
-    private final File file;
+    private final Path path;
     private long lastUse;
 
     /**
-     * File cache of given file, using given converter factory.
+     * File cache of given path, using given converter factory.
      * @param converterFactory converter factory to create a converter to write files with.
-     * @param file file to cache.
-     * @param record example record to create converter from, this is not written to file.
+     * @param path path to cache.
+     * @param record example record to create converter from, this is not written to path.
      * @param gzip whether to gzip the records
      * @throws IOException
      */
-    public FileCache(RecordConverterFactory converterFactory, File file,
+    public FileCache(RecordConverterFactory converterFactory, Path path,
             GenericRecord record, boolean gzip) throws IOException {
-        this.file = file;
-        boolean fileIsNew = !file.exists() || file.length() == 0;
+        this.path = path;
+        boolean fileIsNew = !Files.exists(path) || Files.size(path) == 0;
 
         this.streams = new OutputStream[gzip ? 3 : 2];
-        this.streams[0] = new FileOutputStream(file, true);
+        this.streams[0] = new FileOutputStream(path.toFile(), true);
         this.streams[1] = new BufferedOutputStream(this.streams[0]);
         if (gzip) {
             this.streams[2] = new GZIPOutputStream(this.streams[1]);
@@ -83,7 +84,7 @@ public class FileCache implements Closeable, Flushable, Comparable<FileCache> {
 
     /**
      * Compares time that the filecaches were last used. If equal, it lexicographically compares
-     * the absolute path of the file.
+     * the absolute path of the path.
      * @param other FileCache to compare with.
      */
     @Override
@@ -92,11 +93,11 @@ public class FileCache implements Closeable, Flushable, Comparable<FileCache> {
         if (result != 0) {
             return result;
         }
-        return file.compareTo(other.file);
+        return path.compareTo(other.path);
     }
 
     /** File that the cache is maintaining. */
-    public File getFile() {
-        return file;
+    public Path getPath() {
+        return path;
     }
 }

--- a/src/main/java/org/radarcns/util/FileCache.java
+++ b/src/main/java/org/radarcns/util/FileCache.java
@@ -26,13 +26,17 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.zip.GZIPOutputStream;
 import javax.annotation.Nonnull;
 import org.apache.avro.generic.GenericRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Keeps path handles of a path. */
 public class FileCache implements Closeable, Flushable, Comparable<FileCache> {
-    private final OutputStream[] streams;
+    private static final Logger logger = LoggerFactory.getLogger(FileCache.class);
+
     private final Writer writer;
     private final RecordConverter recordConverter;
     private final Path path;
@@ -51,15 +55,25 @@ public class FileCache implements Closeable, Flushable, Comparable<FileCache> {
         this.path = path;
         boolean fileIsNew = !Files.exists(path) || Files.size(path) == 0;
 
-        this.streams = new OutputStream[gzip ? 3 : 2];
-        this.streams[0] = new FileOutputStream(path.toFile(), true);
-        this.streams[1] = new BufferedOutputStream(this.streams[0]);
+        OutputStream outFile = Files.newOutputStream(path,
+                StandardOpenOption.APPEND, StandardOpenOption.CREATE);
+        OutputStream bufOut = new BufferedOutputStream(outFile);
         if (gzip) {
-            this.streams[2] = new GZIPOutputStream(this.streams[1]);
+            bufOut = new GZIPOutputStream(bufOut);
         }
 
-        this.writer = new OutputStreamWriter(this.streams[this.streams.length - 1]);
-        this.recordConverter = converterFactory.converterFor(writer, record, fileIsNew);
+        this.writer = new OutputStreamWriter(bufOut);
+
+        try {
+            this.recordConverter = converterFactory.converterFor(writer, record, fileIsNew);
+        } catch (IOException ex) {
+            try {
+                writer.close();
+            } catch (IOException exClose) {
+                logger.error("Failed to close writer for {}", path, ex);
+            }
+            throw ex;
+        }
     }
 
     /** Write a record to the cache. */
@@ -72,9 +86,6 @@ public class FileCache implements Closeable, Flushable, Comparable<FileCache> {
     public void close() throws IOException {
         recordConverter.close();
         writer.close();
-        for (int i = streams.length - 1; i >= 0; i--) {
-            streams[i].close();
-        }
     }
 
     @Override

--- a/src/main/java/org/radarcns/util/JsonAvroConverter.java
+++ b/src/main/java/org/radarcns/util/JsonAvroConverter.java
@@ -21,6 +21,12 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.util.MinimalPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.GenericRecord;
+
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.ByteBuffer;
@@ -28,11 +34,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.avro.Schema;
-import org.apache.avro.Schema.Field;
-import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericFixed;
-import org.apache.avro.generic.GenericRecord;
 
 /**
  * Writes an Avro record to JSON format.

--- a/src/main/java/org/radarcns/util/RecordConverter.java
+++ b/src/main/java/org/radarcns/util/RecordConverter.java
@@ -17,8 +17,11 @@
 package org.radarcns.util;
 
 import java.io.Closeable;
+import java.io.File;
 import java.io.Flushable;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import org.apache.avro.generic.GenericRecord;
 

--- a/src/test/java/org/radarcns/OffsetRangeFileTest.java
+++ b/src/test/java/org/radarcns/OffsetRangeFileTest.java
@@ -16,21 +16,20 @@
 
 package org.radarcns;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.nio.file.Files;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class OffsetRangeFileTest {
     @Rule
@@ -38,18 +37,18 @@ public class OffsetRangeFileTest {
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
-    private File testFile;
+    private Path testFile;
 
     @Before
     public void setUp() throws IOException {
-        testFile = folder.newFile();
+        testFile = folder.newFile().toPath();
     }
 
     @Test
     public void readEmpty() throws IOException {
         assertTrue(OffsetRangeFile.read(testFile).isEmpty());
 
-        assertTrue(testFile.delete());
+        Files.delete(testFile);
 
         // will create on write
         try (OffsetRangeFile.Writer ignored = new OffsetRangeFile.Writer(testFile)) {
@@ -63,7 +62,7 @@ public class OffsetRangeFileTest {
             rangeFile.write(OffsetRange.parseFilename("a+0+0+1"));
             rangeFile.write(OffsetRange.parseFilename("a+0+1+2"));
         }
-        System.out.println(new String(Files.readAllBytes(testFile.toPath())));
+        System.out.println(new String(Files.readAllBytes(testFile)));
 
         OffsetRangeSet set = OffsetRangeFile.read(testFile);
         System.out.println(set);
@@ -84,8 +83,7 @@ public class OffsetRangeFileTest {
             rangeFile.write(OffsetRange.parseFilename("a+0+4+4"));
         }
 
-        try (FileReader fr = new FileReader(testFile);
-             BufferedReader br = new BufferedReader(fr)) {
+        try (BufferedReader br = Files.newBufferedReader(testFile)) {
             assertEquals(4, br.lines().count());
         }
 
@@ -94,8 +92,7 @@ public class OffsetRangeFileTest {
 
         OffsetRangeFile.cleanUp(testFile);
 
-        try (FileReader fr = new FileReader(testFile);
-             BufferedReader br = new BufferedReader(fr)) {
+        try (BufferedReader br = Files.newBufferedReader(testFile)) {
             assertEquals(3, br.lines().count());
         }
 

--- a/src/test/java/org/radarcns/util/FileCacheStoreTest.java
+++ b/src/test/java/org/radarcns/util/FileCacheStoreTest.java
@@ -23,6 +23,8 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericRecord;
@@ -37,14 +39,14 @@ public class FileCacheStoreTest {
 
     @Test
     public void appendLine() throws IOException {
-        File f1 = folder.newFile();
-        File f2 = folder.newFile();
-        File f3 = folder.newFile();
-        File d4 = folder.newFolder();
-        File f4 = new File(d4, "f4.txt");
+        Path f1 = folder.newFile().toPath();
+        Path f2 = folder.newFile().toPath();
+        Path f3 = folder.newFile().toPath();
+        Path d4 = folder.newFolder().toPath();
+        Path f4 = d4.resolve("f4.txt");
 
-        assertTrue(f1.delete());
-        assertTrue(d4.delete());
+        Files.delete(f1);
+        Files.delete(d4);
 
         RecordConverterFactory csvFactory = CsvAvroConverter.getFactory();
         Schema simpleSchema = SchemaBuilder.record("simple").fields()
@@ -53,7 +55,7 @@ public class FileCacheStoreTest {
 
         GenericRecord record;
 
-        try (FileCacheStore cache = new FileCacheStore(csvFactory, 2, false)) {
+        try (FileCacheStore cache = new FileCacheStore(csvFactory, 2, false, false)) {
             record = new GenericRecordBuilder(simpleSchema).set("a", "something").build();
             assertFalse(cache.writeRecord(f1, record));
             record = new GenericRecordBuilder(simpleSchema).set("a", "somethingElse").build();
@@ -74,9 +76,9 @@ public class FileCacheStoreTest {
             assertTrue(cache.writeRecord(f3, record));
         }
 
-        assertEquals("a\nsomething\nsomethingElse\nthird\n", new String(Files.readAllBytes(f1.toPath())));
-        assertEquals("a\nsomething\nf2\n", new String(Files.readAllBytes(f2.toPath())));
-        assertEquals("a\nf3\nf3\nf3\n", new String(Files.readAllBytes(f3.toPath())));
-        assertEquals("a\nf4\n", new String(Files.readAllBytes(f4.toPath())));
+        assertEquals("a\nsomething\nsomethingElse\nthird\n", new String(Files.readAllBytes(f1)));
+        assertEquals("a\nsomething\nf2\n", new String(Files.readAllBytes(f2)));
+        assertEquals("a\nf3\nf3\nf3\n", new String(Files.readAllBytes(f3)));
+        assertEquals("a\nf4\n", new String(Files.readAllBytes(f4)));
     }
 }

--- a/src/test/java/org/radarcns/util/FileCacheTest.java
+++ b/src/test/java/org/radarcns/util/FileCacheTest.java
@@ -16,17 +16,6 @@
 
 package org.radarcns.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.util.zip.GZIPInputStream;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData.Record;
@@ -36,19 +25,31 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.GZIPInputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 /**
  * Created by joris on 03/07/2017.
  */
 public class FileCacheTest {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
-    private File file;
+    private Path path;
     private RecordConverterFactory csvFactory;
     private Record exampleRecord;
 
     @Before
     public void setUp() throws IOException {
-        this.file = folder.newFile("f");
+        this.path = folder.newFile("f").toPath();
         this.csvFactory = CsvAvroConverter.getFactory();
         Schema schema = SchemaBuilder.record("simple").fields()
                 .name("a").type("string").noDefault()
@@ -58,16 +59,16 @@ public class FileCacheTest {
 
     @Test
     public void testGzip() throws IOException {
-        try (FileCache cache = new FileCache(csvFactory, file, exampleRecord, true)) {
+        try (FileCache cache = new FileCache(csvFactory, path, exampleRecord, true)) {
             cache.writeRecord(exampleRecord);
         }
 
-        System.out.println("Gzip: " + file.length());
+        System.out.println("Gzip: " + Files.size(path));
 
-        try (FileInputStream fin = new FileInputStream(file);
-                GZIPInputStream gzipIn = new GZIPInputStream(fin);
-                Reader readerIn = new InputStreamReader(gzipIn);
-                BufferedReader reader = new BufferedReader(readerIn)) {
+        try (InputStream fin = Files.newInputStream(path);
+             GZIPInputStream gzipIn = new GZIPInputStream(fin);
+             Reader readerIn = new InputStreamReader(gzipIn);
+             BufferedReader reader = new BufferedReader(readerIn)) {
             assertEquals("a", reader.readLine());
             assertEquals("something", reader.readLine());
             assertNull(reader.readLine());
@@ -76,20 +77,20 @@ public class FileCacheTest {
 
     @Test
     public void testGzipAppend() throws IOException {
-        try (FileCache cache = new FileCache(csvFactory, file, exampleRecord, true)) {
+        try (FileCache cache = new FileCache(csvFactory, path, exampleRecord, true)) {
             cache.writeRecord(exampleRecord);
         }
 
-        try (FileCache cache = new FileCache(csvFactory, file, exampleRecord, true)) {
+        try (FileCache cache = new FileCache(csvFactory, path, exampleRecord, true)) {
             cache.writeRecord(exampleRecord);
         }
 
-        System.out.println("Gzip appended: " + file.length());
+        System.out.println("Gzip appended: " + Files.size(path));
 
-        try (FileInputStream fin = new FileInputStream(file);
-                GZIPInputStream gzipIn = new GZIPInputStream(fin);
-                Reader readerIn = new InputStreamReader(gzipIn);
-                BufferedReader reader = new BufferedReader(readerIn)) {
+        try (InputStream fin = Files.newInputStream(path);
+             GZIPInputStream gzipIn = new GZIPInputStream(fin);
+             Reader readerIn = new InputStreamReader(gzipIn);
+             BufferedReader reader = new BufferedReader(readerIn)) {
             assertEquals("a", reader.readLine());
             assertEquals("something", reader.readLine());
             assertEquals("something", reader.readLine());
@@ -100,14 +101,13 @@ public class FileCacheTest {
 
     @Test
     public void testPlain() throws IOException {
-        try (FileCache cache = new FileCache(csvFactory, file, exampleRecord, false)) {
+        try (FileCache cache = new FileCache(csvFactory, path, exampleRecord, false)) {
             cache.writeRecord(exampleRecord);
         }
 
-        System.out.println("Plain: " + file.length());
+        System.out.println("Plain: " + Files.size(path));
 
-        try (FileReader readerIn = new FileReader(file);
-                BufferedReader reader = new BufferedReader(readerIn)) {
+        try (BufferedReader reader = Files.newBufferedReader(path)) {
             assertEquals("a", reader.readLine());
             assertEquals("something", reader.readLine());
             assertNull(reader.readLine());
@@ -116,18 +116,17 @@ public class FileCacheTest {
 
     @Test
     public void testPlainAppend() throws IOException {
-        try (FileCache cache = new FileCache(csvFactory, file, exampleRecord, false)) {
+        try (FileCache cache = new FileCache(csvFactory, path, exampleRecord, false)) {
             cache.writeRecord(exampleRecord);
         }
 
-        try (FileCache cache = new FileCache(csvFactory, file, exampleRecord, false)) {
+        try (FileCache cache = new FileCache(csvFactory, path, exampleRecord, false)) {
             cache.writeRecord(exampleRecord);
         }
 
-        System.out.println("Plain appended: " + file.length());
+        System.out.println("Plain appended: " + Files.size(path));
 
-        try (FileReader readerIn = new FileReader(file);
-                BufferedReader reader = new BufferedReader(readerIn)) {
+        try (BufferedReader reader = Files.newBufferedReader(path)) {
             assertEquals("a", reader.readLine());
             assertEquals("something", reader.readLine());
             assertEquals("something", reader.readLine());
@@ -137,11 +136,11 @@ public class FileCacheTest {
 
     @Test
     public void compareTo() throws IOException {
-        File file3 = folder.newFile("g");
+        Path file3 = folder.newFile("g").toPath();
 
-        try (FileCache cache1 = new FileCache(csvFactory, file, exampleRecord, false);
-                FileCache cache2 = new FileCache(csvFactory, file, exampleRecord, false);
-                FileCache cache3 = new FileCache(csvFactory, file3, exampleRecord, false)) {
+        try (FileCache cache1 = new FileCache(csvFactory, path, exampleRecord, false);
+             FileCache cache2 = new FileCache(csvFactory, path, exampleRecord, false);
+             FileCache cache3 = new FileCache(csvFactory, file3, exampleRecord, false)) {
             assertEquals(0, cache1.compareTo(cache2));
             // filenames are not equal
             assertEquals(-1, cache1.compareTo(cache3));


### PR DESCRIPTION
Changes since version 0.2.1:
- Prefer `java.nio.file.Path` over `java.io.File`.
- Deduplicate and sort output files after writing. This may help with compression as well, since only a single GZIP table is then used for the entire file.